### PR TITLE
Fixes

### DIFF
--- a/R/getArtificialDoublets.R
+++ b/R/getArtificialDoublets.R
@@ -70,7 +70,7 @@ getArtificialDoublets <- function( x, n=3000, prop.fullyRandom=0, clusters=NULL,
     ad.m <- cbind(ad.m, m2)
   }
   
-  if(meta.triplets){
+  if(meta.triplets && length(unique(clusters)) >= 3){
     # create triplets from meta cells:
     if(length(unique(clusters))^3 > n){
       tt <- table(clusters)
@@ -87,7 +87,7 @@ getArtificialDoublets <- function( x, n=3000, prop.fullyRandom=0, clusters=NULL,
     ca <- expand.grid(i, i, i)
     ca <- ca[apply(ca,1,FUN=function(x){ length(unique(x)) })==3,]
     m2 <- meta[,ca[,1]]+meta[,ca[,2]]+meta[,ca[,3]]
-    colnames(m2) <- paste0("arificialTriplet.", ncol(ad.m)+seq_len(ncol(m2)))
+    colnames(m2) <- paste0("artificialTriplet.", ncol(ad.m)+seq_len(ncol(m2)))
     ad.m <- cbind(ad.m, m2)
   }
   ad.m

--- a/R/scDblFinder.R
+++ b/R/scDblFinder.R
@@ -7,11 +7,11 @@
 #' @param artificialDoublets The approximate number of artificial doublets to 
 #' create. If NULL, will be the maximum of the number of cells or 
 #' `3*nbClusters^2`.
-#' @param clusters The optional cluster assignments (if ommitted, will run 
+#' @param clusters The optional cluster assignments (if omitted, will run 
 #' `quickCluster`). This is used to make doublets more efficiently.
 #' @param samples A vector of the same length as cells (or the name of a column 
 #' of `colData(sce)`), indicating to which sample each cell belongs. Here, a 
-#' sample is understood as being processed independently. If ommitted, doublets 
+#' sample is understood as being processed independently. If omitted, doublets 
 #' will be searched for with all cells together. If given, doublets will be 
 #' searched for independently for each sample, which is preferable if they 
 #' represent different captures.
@@ -73,8 +73,6 @@ scDblFinder <- function( sce, artificialDoublets=NULL, clusters=NULL,
   if( !("counts" %in% assayNames(sce)) ) 
       stop("`sce` should have an assay named 'counts'")
   if(!is.null(samples)){
-    test_that( "Samples vector matches number of cells", 
-               expect_equal(ncol(sce), length(samples)) )
     # splitting by samples
     if(length(samples)==1 && samples %in% colnames(colData(sce)))
         samples <- colData(sce)[[samples]]
@@ -103,6 +101,7 @@ numbers of cells.")
       dbr <- (0.01*ncol(sce)/1000)
   }
   if(is.null(clusters)) clusters <- .getClusters(sce, maxClusSize, minClusSize)
+  if(length(unique(clusters)) == 1) stop("Only one cluster generated")
   maxSameDoublets <- length(clusters)*(dbr+2*dbr.sd) * 
       prod(sort(table(clusters), decreasing=TRUE)[1:2] / length(clusters))
   if(min(table(clusters)) <= maxSameDoublets){


### PR DESCRIPTION
Supposedly fixes the following issues:
- Triplets can not be created if the number of clusters is less than 3 (`ca` is empty)
- `maxSameDoublets` explicitly extracts 2 elements from `table(clusters)`, which will fail with a not very informative error message if there is only one cluster. 
- Providing a column ID for `samples` failed since the check for equal length to `ncol(sce)` was done on the provided string.

One more thing:
- The `scDblFinder.score` column is seemingly not returned if `samples` is provided - indicate this in the documentation? As a consequence, I think the corresponding examples in the README/vignette would fail if they were actually run.

I'd also suggest adding some unit tests to catch potential issues like these. 