### PR TITLE
Refer to the right internal function in tests.

### DIFF
--- a/R/computeDoubletDensity.R
+++ b/R/computeDoubletDensity.R
@@ -18,7 +18,6 @@
 #' @param niters An integer scalar specifying how many simulated doublets should be generated.
 #' @param block An integer scalar controlling the rate of doublet generation, to keep memory usage low.
 #' @param dims An integer scalar specifying the number of components to retain after the PCA.
-#' @param adjust Logical scalar indicating whether to adjust for differences in local density, see the vignette.
 #' @param BNPARAM A \linkS4class{BiocNeighborParam} object specifying the nearest neighbor algorithm.
 #' This should be an algorithm supported by \code{\link{findNeighbors}}.
 #' @param BSPARAM A \linkS4class{BiocSingularParam} object specifying the algorithm to use for PCA, if \code{d} is not \code{NA}.

--- a/man/computeDoubletDensity.Rd
+++ b/man/computeDoubletDensity.Rd
@@ -63,8 +63,6 @@ This should be an algorithm supported by \code{\link{findNeighbors}}.}
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object specifying whether the neighbour searches should be parallelized.}
 
 \item{assay.type}{A string specifying which assay values contain the count matrix.}
-
-\item{adjust}{Logical scalar indicating whether to adjust for differences in local density, see the vignette.}
 }
 \value{
 A numeric vector of doublet scores for each cell in \code{x}.

--- a/tests/testthat/test-computeDoubletDensity.R
+++ b/tests/testthat/test-computeDoubletDensity.R
@@ -21,7 +21,7 @@ test_that("computeDoubletDensity PC spawning works correctly", {
     SVD <- svd(t(y - centers), nv=20)
 
     set.seed(12345)
-    sim.pcs <- scran:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=10000L, block=10000L)
+    sim.pcs <- scDblFinder:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=10000L, block=10000L)
 
     set.seed(12345)
     L <- sample(ncol(counts), 10000L, replace=TRUE)
@@ -34,12 +34,12 @@ test_that("computeDoubletDensity PC spawning works correctly", {
 
     # Works with multiple iterations.
     set.seed(23456)
-    sim.pcs <- scran:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=25000L, block=10000L)
+    sim.pcs <- scDblFinder:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=25000L, block=10000L)
 
     set.seed(23456)
-    ref1 <- scran:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=10000L, block=10000L)
-    ref2 <- scran:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=10000L, block=10000L)
-    ref3 <- scran:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=5000L, block=10000L)
+    ref1 <- scDblFinder:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=10000L, block=10000L)
+    ref2 <- scDblFinder:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=10000L, block=10000L)
+    ref3 <- scDblFinder:::.spawn_doublet_pcs(counts, sf, SVD$v, centers, niters=5000L, block=10000L)
 
     expect_equal(sim.pcs, rbind(ref1, ref2, ref3))
     expect_identical(dim(sim.pcs), c(25000L, ncol(SVD$v)))


### PR DESCRIPTION
Well, that was embarrassing; a copy-paste error that went unnoticed until I deleted some functions from **scran** in BioC-devel.

Closes #28. I'll have to put **scDblFinder** on my wall to track its status.