### PR TITLE
fix typo in sample param description

### DIFF
--- a/R/scDblFinder.R
+++ b/R/scDblFinder.R
@@ -22,7 +22,7 @@
 #' will be searched for with all cells together. If given, doublets will be
 #' searched for independently for each sample, which is preferable if they
 #' represent different captures. If your samples were multiplexed using cell
-#' hashes, want you want to give here are the different batches/wells (i.e.
+#' hashes, what you want to give here are the different batches/wells (i.e.
 #' independent captures, since doublets cannot arise across them) rather
 #' than biological samples.
 #' @param multiSampleMode Either "split" (recommended if there is


### PR DESCRIPTION
Fixing a typo to clarify wording for the `samples` param.