### PR TITLE
Pass on `nthreads` to `xgboost` functions in `scDblFinder`

### DIFF
--- a/R/scDblFinder.R
+++ b/R/scDblFinder.R
@@ -766,7 +766,8 @@ scDblFinder <- function(
       max_depth=max_depth,
       learning_rate=eta,
       subsample=subsample,
-      tree_method=tree_method
+      tree_method=tree_method,
+      nthread=nthreads
     )
     
     res <- xgb.cv(
@@ -804,6 +805,7 @@ scDblFinder <- function(
     subsample=subsample,
     tree_method=tree_method,
     early_stopping_rounds=2,
+    nthreads=nthreads,
     ...
   )
 }


### PR DESCRIPTION
We recently had some cases where `scDblFinder()` would grab all the cores on the machine, and run very slowly. Passing the `nthreads` parameter to the `xgboost` functions (which I believe would otherwise resort to `parallel::detectCores()`) seems to improve the situation and it finishes quickly (although as far as I can see it still uses a bit more CPU than specified via `BPPARAM`). The code below was enough to trigger the issue (both with versions 1.24.10 and 1.25.4):

```
library(scDblFinder)
library(SingleCellExperiment)
sce <- mockDoubletSCE(ncells = c(2000, 3000, 5000), ngenes = 10000)
sce <- scDblFinder(sce, BPPARAM=BiocParallel::SerialParam())
```

Is this something that you have also run into?

cc @mbstadler